### PR TITLE
Allow selecting by names not in the manifest

### DIFF
--- a/ext/MurmurHash3/MurmurHash3.cpp
+++ b/ext/MurmurHash3/MurmurHash3.cpp
@@ -1,0 +1,335 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+#include "MurmurHash3.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE	__forceinline
+
+#include <stdlib.h>
+
+#define ROTL32(x,y)	_rotl(x,y)
+#define ROTL64(x,y)	_rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x)
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#define	FORCE_INLINE inline __attribute__((always_inline))
+
+inline uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+inline uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
+{
+  return p[i];
+}
+
+FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
+{
+  return p[i];
+}
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+FORCE_INLINE uint32_t fmix32 ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 ( const void * key, int len,
+                          uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+    
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_128 ( const void * key, const int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  const uint32_t c1 = 0x239b961b; 
+  const uint32_t c2 = 0xab0e9789;
+  const uint32_t c3 = 0x38b34ae5; 
+  const uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128 ( const void * key, const int len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(int i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+  case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------
+

--- a/ext/MurmurHash3/MurmurHash3.h
+++ b/ext/MurmurHash3/MurmurHash3.h
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH3_H_

--- a/src/aftereffects/Cryptomatte_AE.cpp
+++ b/src/aftereffects/Cryptomatte_AE.cpp
@@ -55,10 +55,10 @@ bool
 GetHashIfLiteral(const std::string &name, Hash &result)
 {
 	// returns true if a literal value, and writes the hash to result. 
-	if(name.size() == 8)
+	if(name.size() == 10)
 	{
 		unsigned long intValue = 0;
-		const int matched = sscanf(name.c_str(), "%x", &intValue);
+		const int matched = sscanf(name.c_str(), "<%x>", &intValue);
 		if (matched) {
 			result = intValue;
 			return true;
@@ -71,7 +71,7 @@ std::string
 HashToLiteralStr(Hash hash)
 {
 	char hexStr[9];
-	sprintf(hexStr, "%08x", hash);
+	sprintf(hexStr, "<%08x>", hash);
 	return std::string(hexStr);
 }
 
@@ -900,14 +900,11 @@ CryptomatteContext::ItemForHash(const Hash &hash) const
 		for(std::vector<std::string>::const_iterator i = tokens.begin(); i != tokens.end(); ++i)
 		{
 			const std::string val = deQuote(*i);
-			if(val.length() == 8)
-			{
-				// to do: replace with better literal number detection.
-				unsigned int intValue = 0;
-				const int matched = sscanf(val.c_str(), "%x", &intValue);
-				if(matched && intValue == hash)
-					return val;
-			}
+
+			Hash literalHash;
+			if(GetHashIfLiteral(val, literalHash) && literalHash == hash)
+				return val;
+
 			if(HashName(val) == hash)
 				return val;
 		}

--- a/src/aftereffects/Cryptomatte_AE.cpp
+++ b/src/aftereffects/Cryptomatte_AE.cpp
@@ -12,6 +12,8 @@
 
 #include "Cryptomatte_AE_Dialog.h"
 
+#include "MurmurHash3.h"
+
 #include "picojson.h"
 
 #include <assert.h>
@@ -133,17 +135,16 @@ CryptomatteContext::Update(CryptomatteArbitraryData *arb)
 	if(_selectionHash != arb->selection_hash)
 	{
 		_selectionHash = arb->selection_hash;
+		_selection = GetSelection(arb);
 
 		_float_selection.clear();
 
 		try
-		{
-			const std::string selectionString = GetSelection(arb);
-			
-			if(!selectionString.empty())
+		{			
+			if(!_selection.empty())
 			{
 				std::vector<std::string> tokens;
-				quotedTokenize(selectionString, tokens, ", ");
+				quotedTokenize(_selection, tokens, ", ");
 				
 				for(std::vector<std::string>::const_iterator i = tokens.begin(); i != tokens.end(); ++i)
 				{
@@ -168,6 +169,10 @@ CryptomatteContext::Update(CryptomatteArbitraryData *arb)
 							_float_selection.insert( HashToFloatHash(hash) );
 						
 						}
+					}
+					else if(val.size())
+					{	
+						_float_selection.insert(HashToFloatHash(HashName(val)));
 					}
 				}
 			}
@@ -595,6 +600,20 @@ CryptomatteContext::FloatHashToHash(const FloatHash &floatHash)
 	return result;
 }
 
+Hash
+CryptomatteContext::HashName(const std::string &name)
+{
+	Hash hash;
+	MurmurHash3_x86_32(name.c_str(), name.length(), 0, &hash);
+
+	// if all exponent bits are 0 (subnormals, +zero, -zero) set exponent to 1
+	// if all exponent bits are 1 (NaNs, +inf, -inf) set exponent to 254
+	Hash exponent = hash >> 23 & 255; // extract exponent (8 bits)
+	if(exponent == 0 || exponent == 255)
+		hash ^= 1 << 23; // toggle bit
+
+	return hash;
+}
 
 CryptomatteContext::Level::Level(PF_InData *in_data, PF_ChannelRef &hash, PF_ChannelRef &coverage) :
 	_hash(NULL),
@@ -861,32 +880,46 @@ CryptomatteContext::Level::FloatBuffer::~FloatBuffer()
 		free(_buf);
 }
 
-
 std::string
 CryptomatteContext::ItemForHash(const Hash &hash) const
 {
-	std::string item;
-	
-	for(std::map<std::string, Hash>::const_iterator j = _manifest.begin(); j != _manifest.end() && item.empty(); ++j)
+	// first check the selection
+	if(_selection.length())
+	{
+		std::vector<std::string> tokens;
+		quotedTokenize(_selection, tokens, ", ");
+
+		for(std::vector<std::string>::const_iterator i = tokens.begin(); i != tokens.end(); ++i)
+		{
+			const std::string val = deQuote(*i);
+			if(val.length() == 8)
+			{
+				// to do: replace with better literal number detection.
+				unsigned int intValue = 0;
+				const int matched = sscanf(val.c_str(), "%x", &intValue);
+				if(matched && intValue == hash)
+					return val;
+			}
+			if(HashName(val) == hash)
+				return val;
+		}
+	}
+
+	// then check the manifest
+	for(std::map<std::string, Hash>::const_iterator j = _manifest.begin(); j != _manifest.end(); ++j)
 	{
 		const std::string &name = j->first;
 		const Hash &value = j->second;
-		
+
 		if(hash == value)
-			item = name;
-	}
-	
-	if( item.empty() )
-	{
-		char hexStr[9];
-		sprintf(hexStr, "%08x", hash);
-		
-		item = hexStr;
+			return name;
 	}
 
-	return item;
+	// finally, use a hex code
+	char hexStr[9];
+	sprintf(hexStr, "%08x", hash);
+	return hexStr;
 }
-
 
 void
 CryptomatteContext::CalculateNextNames(std::string &nextHashName, std::string &nextCoverageName, NamingStyle style) const

--- a/src/aftereffects/Cryptomatte_AE.h
+++ b/src/aftereffects/Cryptomatte_AE.h
@@ -163,12 +163,14 @@ class CryptomatteContext
 	typedef float FloatHash;
 	
 	std::string _layer;
+	std::string _selection;
 	std::map<std::string, Hash> _manifest;
 	std::set<FloatHash> _float_selection; // stored as FloatHash for fast ==
 	
 	static FloatHash HashToFloatHash(const Hash &hash);
 	static Hash FloatHashToHash(const FloatHash &floatHash);
-	
+	static Hash HashName(const std::string &name);
+
 	class Level
 	{
 	  public:

--- a/src/aftereffects/Cryptomatte_AE_ArbData.cpp
+++ b/src/aftereffects/Cryptomatte_AE_ArbData.cpp
@@ -12,6 +12,7 @@
 //
 
 #include "Cryptomatte_AE.h"
+#include "MurmurHash3.h"
 
 #ifndef __MACH__
 #include <assert.h>
@@ -47,14 +48,14 @@ djb2(const A_u_char *data, size_t len)
 static void
 HashManifest(CryptomatteArbitraryData *arb)
 {
-	arb->manifest_hash = djb2((A_u_char *)&arb->data[0], arb->manifest_size);
+	MurmurHash3_x86_32(&arb->data[0], arb->manifest_size, 0, &arb->manifest_hash);;
 }
 
 
 static void
 HashSelection(CryptomatteArbitraryData *arb)
 {
-	arb->selection_hash = djb2((A_u_char *)&arb->data[arb->manifest_size], arb->selection_size);
+	MurmurHash3_x86_32(&arb->data[arb->manifest_size], arb->selection_size, 0, &arb->selection_hash);
 }
 
 

--- a/src/aftereffects/Cryptomatte_AE_ArbData.cpp
+++ b/src/aftereffects/Cryptomatte_AE_ArbData.cpp
@@ -33,18 +33,6 @@ SwapArbData(CryptomatteArbitraryData *arb_data)
 }
 
 
-static Hash
-djb2(const A_u_char *data, size_t len)
-{
-	Hash hash = 5381;
-	
-	while(len--)
-		hash = ((hash << 5) + hash) + *data++; // hash * 33 + c
-	
-	return hash;
-}
-
-
 static void
 HashManifest(CryptomatteArbitraryData *arb)
 {

--- a/vc/vc9/Cryptomatte.vcproj
+++ b/vc/vc9/Cryptomatte.vcproj
@@ -49,7 +49,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Util&quot;;..\..\ext\picojson"
+				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Util&quot;;..\..\ext\picojson;..\..\ext\MurmurHash3;"
 				PreprocessorDefinitions="MSWindows;WIN32;_DEBUG;_WINDOWS"
 				RuntimeLibrary="3"
 				StructMemberAlignment="3"
@@ -149,7 +149,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
-				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Util&quot;;..\..\ext\picojson"
+				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CC 2015 Win SDK\Examples\Util&quot;;..\..\ext\picojson;..\..\ext\MurmurHash3;"
 				PreprocessorDefinitions="MSWindows;WIN32;NDEBUG;_WINDOWS"
 				RuntimeLibrary="2"
 				StructMemberAlignment="3"
@@ -248,7 +248,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Util&quot;;..\..\ext\picojson"
+				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Util&quot;;..\..\ext\picojson;..\..\ext\MurmurHash3;"
 				PreprocessorDefinitions="MSWindows;WIN32;_DEBUG;_WINDOWS"
 				RuntimeLibrary="3"
 				StructMemberAlignment="3"
@@ -348,7 +348,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
-				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Util&quot;;..\..\ext\picojson"
+				AdditionalIncludeDirectories="..\..\src\aftereffects;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\SP&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Headers\Win&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Resources&quot;;&quot;..\..\ext\Adobe After Effects CS6 Win SDK\Examples\Util&quot;;..\..\ext\picojson;..\..\ext\MurmurHash3;"
 				PreprocessorDefinitions="MSWindows;WIN32;NDEBUG;_WINDOWS"
 				RuntimeLibrary="2"
 				StructMemberAlignment="3"
@@ -431,6 +431,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\aftereffects\fnord_SuiteHandler.cpp"
+				>
+			</File>
+			<File
+				RelativePath="..\..\ext\MurmurHash3\MurmurHash3.cpp"
 				>
 			</File>
 		</Filter>


### PR DESCRIPTION
This allows selecting by name if the manifest is missing, by manually typing or pasting in selection text.  This is good to have because manifests can be incomplete on some or all frames. 

The edge cases:
- After items are selected by name while not in the manifest, this also allows them to be deselected by clicking. 
- If an item is redundantly selected (for example: "<41c3eaf9>, grass_mat"), deselected it by clicking will only remove one of the items, but a second click will remove the other. 

I have also changed the format of literal hash value to <########> to decrease ambiguity about what is a literal ID value and what isn't. 